### PR TITLE
Fix README.md build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Firefox SVG Assets  [![Build Status](https://travis-ci.org/FirefoxUX/firefox-icons.svg?branch=master)](https://travis-ci.org/FirefoxUX/firefox-icons)
+# Firefox SVG Assets  [![Build Status](https://travis-ci.org/FirefoxUX/icons.svg?branch=master)](https://travis-ci.org/FirefoxUX/icons)
 If you'd like to contribute SVG assets to Firefox, this is meant to be a handy guide for making sure you SVGs are compressed and neatly formatted as possible :tada:
 
 ## Table of Contents


### PR DESCRIPTION
The current build status badge points to the now non-existent “FirefoxUX/firefox-icons” repository (presumably what this repository used to be called before it was renamed), this fix points it to the correct “FirefoxUX/icons” location.